### PR TITLE
Coerce zeroconf IP address and port

### DIFF
--- a/custom_components/vinx/config_flow.py
+++ b/custom_components/vinx/config_flow.py
@@ -67,8 +67,8 @@ class VinxConfigFlow(ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         # Pre-populate the form
-        self.host = discovery_info.ip_address
-        self.port = discovery_info.port
+        self.host = str(discovery_info.ip_address)
+        self.port = int(discovery_info.port)
 
         # Trigger the user configuration flow
         return await self.async_step_user()


### PR DESCRIPTION
```
2024-09-11 08:58:39.039 ERROR (MainThread) [homeassistant.helpers.http] Unable to serialize to JSON. Bad data found at $.data_schema[0].default=10.211.0.74(<class 'zeroconf._utils.ipaddress.ZeroconfIPv4Address'>
```