### PR TITLE
Log the response that triggered the error

### DIFF
--- a/custom_components/vinx/lw3.py
+++ b/custom_components/vinx/lw3.py
@@ -63,7 +63,7 @@ def get_response_type(response: str) -> ResponseType:
     elif response[0] == "m":
         return ResponseType.Method
 
-    raise ValueError("Unknown response type")
+    raise ValueError(f"Unknown response type: {response}")
 
 
 def parse_single_line_response(response: str) -> SingleLineResponse:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 942, in async_update_ha_state
    await self.async_device_update()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1300, in async_device_update
    await self.async_update()
  File "/config/custom_components/vinx/media_player.py", line 97, in async_update
    video_channel_id = await self._lw3.get_property("/SYS/MB/PHY.VideoChannelId")
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/vinx/lw3.py", line 179, in get_property
    response = await asyncio.wait_for(self._run_get(path), self._timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/tasks.py", line 520, in wait_for
    return await fut
           ^^^^^^^^^
  File "/config/custom_components/vinx/lw3.py", line 155, in _run_get
    return await self._read_and_parse_response()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/vinx/lw3.py", line 143, in _read_and_parse_response
    result = parse_response(response.strip())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/vinx/lw3.py", line 94, in parse_response
    return parse_single_line_response(lines[1])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/vinx/lw3.py", line 70, in parse_single_line_response
    match get_response_type(response):
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/vinx/lw3.py", line 66, in get_response_type
    raise ValueError("Unknown response type")
ValueError: Unknown response type
``