### PR TITLE
Minor tweaks, add "discover sources" button

### DIFF
--- a/custom_components/vinx/__init__.py
+++ b/custom_components/vinx/__init__.py
@@ -6,6 +6,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.device_registry import DeviceInfo, format_mac
+from homeassistant.helpers.entity import Entity
 
 from custom_components.vinx.const import DOMAIN
 from custom_components.vinx.lw3 import LW3
@@ -88,3 +89,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+class VinxEntity(Entity):
+    """
+    Base class for all entities, provides boilerplate for determining entity unique ID,
+    name and associating with the device.
+    """
+
+    def __init__(self, device_information: DeviceInformation, name: str, unique_id: str) -> None:
+        self._device_information = device_information
+        self._name = name
+        self._unique_id = unique_id
+
+    @property
+    def unique_id(self) -> str:
+        return f"vinx_{self._device_information.mac_address}_{self._unique_id}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return self._device_information.device_info
+
+    @property
+    def name(self) -> str:
+        # Use increasingly less descriptive names depending on what information is available
+        device_label = self._device_information.device_label
+        serial_number = self._device_information.device_info.get("serial_number")
+
+        if device_label:
+            return f"{self._device_information.device_label} {self._name}"
+        elif serial_number:
+            return f"VINX {serial_number} {self._name}"
+        else:
+            return f"VINX {self._name}"

--- a/custom_components/vinx/__init__.py
+++ b/custom_components/vinx/__init__.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import Enum
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -12,12 +13,26 @@ from custom_components.vinx.lw3 import LW3
 PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.BUTTON]
 
 
+class DeviceType(Enum):
+    ENCODER = "encoder"
+    DECODER = "decoder"
+    UNKNOWN = "unknown"
+
+
 @dataclass
 class DeviceInformation:
     mac_address: str
     product_name: str
     device_label: str
     device_info: DeviceInfo
+
+    def get_device_type(self) -> DeviceType:
+        if self.product_name.endswith("ENC"):
+            return DeviceType.ENCODER
+        elif self.product_name.endswith("DEC"):
+            return DeviceType.DECODER
+        else:
+            return DeviceType.UNKNOWN
 
 
 @dataclass

--- a/custom_components/vinx/button.py
+++ b/custom_components/vinx/button.py
@@ -2,9 +2,11 @@ import logging
 
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from custom_components.vinx import LW3, DeviceInformation, VinxRuntimeData
+from custom_components.vinx import LW3, DeviceInformation, VinxRuntimeData, DeviceType
+from custom_components.vinx.const import EVENT_DISCOVER_SOURCES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -14,8 +16,14 @@ async def async_setup_entry(_hass, entry: ConfigEntry, async_add_entities):
     runtime_data: VinxRuntimeData = entry.runtime_data
     _LOGGER.info(f"Runtime data: {runtime_data}")
 
-    # Add entity to Home Assistant
+    # Add reboot button entity
     async_add_entities([VinxRebootButtonEntity(runtime_data.lw3, runtime_data.device_information)])
+
+    # Add discover sources button for decoders
+    device_type = runtime_data.device_information.get_device_type()
+
+    if device_type == DeviceType.DECODER:
+        async_add_entities([VinxDiscoverSourcesButtonEntity(runtime_data.device_information)])
 
 
 class VinxRebootButtonEntity(ButtonEntity):
@@ -50,3 +58,34 @@ class VinxRebootButtonEntity(ButtonEntity):
         async with self._lw3.connection():
             _LOGGER.info("Issuing device reset")
             await self._lw3.call("/SYS", "reset(1)")
+
+
+class VinxDiscoverSourcesButtonEntity(ButtonEntity):
+    def __init__(self, device_information: DeviceInformation):
+        self._device_information = device_information
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def unique_id(self) -> str | None:
+        return f"vinx_{self._device_information.mac_address}_discover_sources_button"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return self._device_information.device_info
+
+    @property
+    def name(self):
+        # Use increasingly less descriptive names depending on what information is available
+        device_label = self._device_information.device_label
+        serial_number = self._device_information.device_info.get("serial_number")
+
+        if device_label:
+            return f"{self._device_information.device_label} discover sources button"
+        elif serial_number:
+            return f"VINX {serial_number} discover sources button"
+        else:
+            return "VINX discover sources button"
+
+    async def async_press(self) -> None:
+        self.hass.bus.async_fire(EVENT_DISCOVER_SOURCES)

--- a/custom_components/vinx/button.py
+++ b/custom_components/vinx/button.py
@@ -3,9 +3,8 @@ import logging
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.helpers.device_registry import DeviceInfo
 
-from custom_components.vinx import LW3, DeviceInformation, VinxRuntimeData, DeviceType
+from custom_components.vinx import LW3, DeviceInformation, DeviceType, VinxEntity, VinxRuntimeData
 from custom_components.vinx.const import EVENT_DISCOVER_SOURCES
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,33 +25,12 @@ async def async_setup_entry(_hass, entry: ConfigEntry, async_add_entities):
         async_add_entities([VinxDiscoverSourcesButtonEntity(runtime_data.device_information)])
 
 
-class VinxRebootButtonEntity(ButtonEntity):
+class VinxRebootButtonEntity(VinxEntity, ButtonEntity):
     def __init__(self, lw3: LW3, device_information: DeviceInformation) -> None:
+        super().__init__(device_information, "reboot button", "reboot_button")
         self._lw3 = lw3
-        self._device_information = device_information
 
     _attr_device_class = ButtonDeviceClass.RESTART
-
-    @property
-    def unique_id(self) -> str | None:
-        return f"vinx_{self._device_information.mac_address}_reboot_button"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return self._device_information.device_info
-
-    @property
-    def name(self):
-        # Use increasingly less descriptive names depending on what information is available
-        device_label = self._device_information.device_label
-        serial_number = self._device_information.device_info.get("serial_number")
-
-        if device_label:
-            return f"{self._device_information.device_label} reboot button"
-        elif serial_number:
-            return f"VINX {serial_number} reboot button"
-        else:
-            return "VINX reboot button"
 
     async def async_press(self) -> None:
         async with self._lw3.connection():
@@ -60,32 +38,11 @@ class VinxRebootButtonEntity(ButtonEntity):
             await self._lw3.call("/SYS", "reset(1)")
 
 
-class VinxDiscoverSourcesButtonEntity(ButtonEntity):
+class VinxDiscoverSourcesButtonEntity(VinxEntity, ButtonEntity):
     def __init__(self, device_information: DeviceInformation):
-        self._device_information = device_information
+        super().__init__(device_information, "discover sources button", "discover_sources_button")
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    @property
-    def unique_id(self) -> str | None:
-        return f"vinx_{self._device_information.mac_address}_discover_sources_button"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return self._device_information.device_info
-
-    @property
-    def name(self):
-        # Use increasingly less descriptive names depending on what information is available
-        device_label = self._device_information.device_label
-        serial_number = self._device_information.device_info.get("serial_number")
-
-        if device_label:
-            return f"{self._device_information.device_label} discover sources button"
-        elif serial_number:
-            return f"VINX {serial_number} discover sources button"
-        else:
-            return "VINX discover sources button"
 
     async def async_press(self) -> None:
         self.hass.bus.async_fire(EVENT_DISCOVER_SOURCES)

--- a/custom_components/vinx/button.py
+++ b/custom_components/vinx/button.py
@@ -9,7 +9,7 @@ from custom_components.vinx import LW3, DeviceInformation, VinxRuntimeData
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities):
+async def async_setup_entry(_hass, entry: ConfigEntry, async_add_entities):
     # Extract stored runtime data
     runtime_data: VinxRuntimeData = entry.runtime_data
     _LOGGER.info(f"Runtime data: {runtime_data}")

--- a/custom_components/vinx/button.py
+++ b/custom_components/vinx/button.py
@@ -45,4 +45,12 @@ class VinxDiscoverSourcesButtonEntity(VinxEntity, ButtonEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     async def async_press(self) -> None:
-        self.hass.bus.async_fire(EVENT_DISCOVER_SOURCES)
+        self.hass.bus.async_fire(
+            EVENT_DISCOVER_SOURCES,
+            {
+                # The same event is sent to all event listeners, but we only want the decoder entity belonging to the
+                # same device as this button to handle the event, so send an identifier here that can be checked in the
+                # listener
+                "device_label": self._device_information.device_label,
+            },
+        )

--- a/custom_components/vinx/config_flow.py
+++ b/custom_components/vinx/config_flow.py
@@ -14,6 +14,7 @@ from .lw3 import LW3
 _LOGGER = logging.getLogger(__name__)
 
 
+# noinspection PyTypeChecker
 class VinxConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
 

--- a/custom_components/vinx/const.py
+++ b/custom_components/vinx/const.py
@@ -4,3 +4,5 @@ CONF_HOST = "host"
 CONF_PORT = "port"
 CONF_PASSWORD = "password"
 CONF_DEVICE_TYPE = "device_type"
+
+EVENT_DISCOVER_SOURCES = f"{DOMAIN}_discover_sources"

--- a/custom_components/vinx/lw3.py
+++ b/custom_components/vinx/lw3.py
@@ -205,12 +205,30 @@ class LW3:
         return response
 
 
+# noinspection PyProtectedMember
 class LW3ConnectionContext:
+    """
+    Connection context that provides exclusive access to the device. Should not be used for long-running operations
+    since that would block others from acquiring the context.
+    """
+
     def __init__(self, lw3: LW3):
         self._lw3 = lw3
+        self._lock = asyncio.Lock()
 
     async def __aenter__(self):
-        await self._lw3._connect()
+        await self._lock.acquire()
+
+        # Avoid deadlock if connect() fails
+        try:
+            await self._lw3._connect()
+        except:
+            self._lock.release()
+            raise
 
     async def __aexit__(self, *args):
-        await self._lw3._disconnect()
+        # Avoid deadlock if disconnect() fails
+        try:
+            await self._lw3._disconnect()
+        finally:
+            self._lock.release()

--- a/custom_components/vinx/media_player.py
+++ b/custom_components/vinx/media_player.py
@@ -9,7 +9,7 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from custom_components.vinx import LW3, DeviceInformation, VinxRuntimeData
+from custom_components.vinx import LW3, DeviceInformation, DeviceType, VinxRuntimeData
 from custom_components.vinx.lw3 import NodeResponse, is_encoder_discovery_node
 
 _LOGGER = logging.getLogger(__name__)
@@ -21,11 +21,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
     _LOGGER.info(f"Runtime data: {runtime_data}")
 
     # Add entity to Home Assistant
-    product_name = runtime_data.device_information.product_name
-    if product_name.endswith("ENC"):
+    device_type = runtime_data.device_information.get_device_type()
+    if device_type == DeviceType.ENCODER:
         async_add_entities([VinxEncoder(runtime_data.lw3, runtime_data.device_information)])
         pass
-    elif product_name.endswith("DEC"):
+    elif device_type == DeviceType.DECODER:
         async_add_entities([VinxDecoder(runtime_data.lw3, runtime_data.device_information)])
         pass
     else:

--- a/custom_components/vinx/media_player.py
+++ b/custom_components/vinx/media_player.py
@@ -8,9 +8,8 @@ from homeassistant.components.media_player import (
     MediaPlayerState,
 )
 from homeassistant.core import Event
-from homeassistant.helpers.device_registry import DeviceInfo
 
-from custom_components.vinx import LW3, DeviceInformation, DeviceType, VinxRuntimeData
+from custom_components.vinx import LW3, DeviceInformation, DeviceType, VinxEntity, VinxRuntimeData
 from custom_components.vinx.const import EVENT_DISCOVER_SOURCES
 from custom_components.vinx.lw3 import NodeResponse, is_encoder_discovery_node
 
@@ -34,41 +33,18 @@ async def async_setup_entry(_hass, entry, async_add_entities):
         _LOGGER.warning("Unknown device type, no entities will be added")
 
 
-class AbstractVinxMediaPlayerEntity(MediaPlayerEntity):
+class AbstractVinxMediaPlayerEntity(VinxEntity, MediaPlayerEntity):
     def __init__(self, lw3: LW3, device_information: DeviceInformation) -> None:
+        super().__init__(device_information, "media player", "media_player")
         self._lw3 = lw3
-        self._device_information = device_information
 
         self._state = MediaPlayerState.IDLE
 
     _attr_device_class = MediaPlayerDeviceClass.RECEIVER
 
     @property
-    def unique_id(self) -> str | None:
-        mac_address = self._device_information.mac_address
-
-        return f"vinx_{mac_address}_media_player"
-
-    @property
     def state(self) -> MediaPlayerState:
         return self._state
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        return self._device_information.device_info
-
-    @property
-    def name(self):
-        # Use increasingly less descriptive names depending on what information is available
-        device_label = self._device_information.device_label
-        serial_number = self._device_information.device_info.get("serial_number")
-
-        if device_label:
-            return f"{self._device_information.device_label} media player"
-        elif serial_number:
-            return f"VINX {serial_number} media player"
-        else:
-            return "VINX media player"
 
 
 class VinxEncoder(AbstractVinxMediaPlayerEntity):

--- a/custom_components/vinx/media_player.py
+++ b/custom_components/vinx/media_player.py
@@ -1,7 +1,12 @@
 import logging
 
 from bidict import bidict
-from homeassistant.components.media_player import MediaPlayerEntity, MediaPlayerEntityFeature, MediaPlayerState
+from homeassistant.components.media_player import (
+    MediaPlayerDeviceClass,
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+)
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from custom_components.vinx import LW3, DeviceInformation, VinxRuntimeData
@@ -32,12 +37,9 @@ class AbstractVinxMediaPlayerEntity(MediaPlayerEntity):
         self._lw3 = lw3
         self._device_information = device_information
 
-        self._device_class = "receiver"
         self._state = MediaPlayerState.IDLE
 
-    @property
-    def device_class(self):
-        return self._device_class
+    _attr_device_class = MediaPlayerDeviceClass.RECEIVER
 
     @property
     def unique_id(self) -> str | None:
@@ -46,7 +48,7 @@ class AbstractVinxMediaPlayerEntity(MediaPlayerEntity):
         return f"vinx_{mac_address}_media_player"
 
     @property
-    def state(self):
+    def state(self) -> MediaPlayerState:
         return self._state
 
     @property

--- a/custom_components/vinx/media_player.py
+++ b/custom_components/vinx/media_player.py
@@ -100,7 +100,12 @@ class VinxDecoder(AbstractVinxMediaPlayerEntity):
         async with self._lw3.connection():
             await self._lw3.set_property("/SYS/MB/PHY.VideoChannelId", video_channel_id)
 
-    async def handle_discover_sources_event(self, _event: Event) -> None:
+    async def handle_discover_sources_event(self, event: Event) -> None:
+        # Discard the event if it's not meant for us
+        event_device_label = event.data.get("device_label")
+        if event_device_label is None or event_device_label != self._device_information.device_label:
+            _LOGGER.debug(f"Discarding {EVENT_DISCOVER_SOURCES} event for device label {event_device_label}")
+
         # Protect against simultaneous calls
         if not self._updating_sources:
             try:

--- a/custom_components/vinx/media_player.py
+++ b/custom_components/vinx/media_player.py
@@ -15,7 +15,7 @@ from custom_components.vinx.lw3 import NodeResponse, is_encoder_discovery_node
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(_hass, entry, async_add_entities):
     # Extract stored runtime data
     runtime_data: VinxRuntimeData = entry.runtime_data
     _LOGGER.info(f"Runtime data: {runtime_data}")

--- a/custom_components/vinx/media_player.py
+++ b/custom_components/vinx/media_player.py
@@ -7,9 +7,11 @@ from homeassistant.components.media_player import (
     MediaPlayerEntityFeature,
     MediaPlayerState,
 )
+from homeassistant.core import Event
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from custom_components.vinx import LW3, DeviceInformation, DeviceType, VinxRuntimeData
+from custom_components.vinx.const import EVENT_DISCOVER_SOURCES
 from custom_components.vinx.lw3 import NodeResponse, is_encoder_discovery_node
 
 _LOGGER = logging.getLogger(__name__)
@@ -82,23 +84,9 @@ class VinxDecoder(AbstractVinxMediaPlayerEntity):
         super().__init__(lw3, device_information)
         self._source = None
         self._source_bidict = bidict()
+        self._updating_sources = False
 
     _attr_supported_features = MediaPlayerEntityFeature.SELECT_SOURCE
-
-    async def async_update(self):
-        # Populate the source list only once
-        if len(self._source_bidict.items()) == 0:
-            await self.populate_source_bidict()
-            _LOGGER.info(f"{self.name} source list populated with {len(self.source_list)} sources")
-
-        async with self._lw3.connection():
-            # Query current source
-            video_channel_id = await self._lw3.get_property("/SYS/MB/PHY.VideoChannelId")
-            self._source = str(self._source_bidict.get(str(video_channel_id)))
-
-            # Query signal status
-            signal_present = await self._lw3.get_property("/MEDIA/VIDEO/I1.SignalPresent")
-            self._state = MediaPlayerState.PLAYING if str(signal_present) == "1" else MediaPlayerState.IDLE
 
     @property
     def source(self) -> str | None:
@@ -109,12 +97,44 @@ class VinxDecoder(AbstractVinxMediaPlayerEntity):
         # Sort the list alphabetically, since the order of discovered devices may differ from device to device.
         return sorted(list(self._source_bidict.values()))
 
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+
+        # Re-populate the source list when EVENT_DISCOVER_DEVICES is fired
+        self.async_on_remove(self.hass.bus.async_listen(EVENT_DISCOVER_SOURCES, self.handle_discover_sources_event))
+
+    async def async_update(self):
+        # Populate the source list if its empty
+        if len(self._source_bidict.items()) == 0:
+            await self.populate_source_bidict()
+
+        async with self._lw3.connection():
+            # Query current source
+            video_channel_id = await self._lw3.get_property("/SYS/MB/PHY.VideoChannelId")
+            self._source = str(self._source_bidict.get(str(video_channel_id)))
+
+            # Query signal status
+            signal_present = await self._lw3.get_property("/MEDIA/VIDEO/I1.SignalPresent")
+            self._state = MediaPlayerState.PLAYING if str(signal_present) == "1" else MediaPlayerState.IDLE
+
     async def async_select_source(self, source: str) -> None:
         self._source = source
         video_channel_id = self._source_bidict.inverse.get(source)
 
         async with self._lw3.connection():
             await self._lw3.set_property("/SYS/MB/PHY.VideoChannelId", video_channel_id)
+
+    async def handle_discover_sources_event(self, _event: Event) -> None:
+        # Protect against simultaneous calls
+        if not self._updating_sources:
+            try:
+                self._updating_sources = True
+
+                # Clear any existing items first
+                self._source_bidict.clear()
+                await self.populate_source_bidict()
+            finally:
+                self._updating_sources = False
 
     async def populate_source_bidict(self):
         """Queries the device for discovered devices, filters out everything that isn't a VINX encoder,
@@ -127,3 +147,5 @@ class VinxDecoder(AbstractVinxMediaPlayerEntity):
                 device_name = await self._lw3.get_property(f"{encoder_node.path}.DeviceName")
                 video_channel_id = await self._lw3.get_property(f"{encoder_node.path}.VideoChannelId")
                 self._source_bidict.put(str(video_channel_id), str(device_name))
+
+        _LOGGER.info(f"{self.name} source list populated with {len(self.source_list)} sources")

--- a/custom_components/vinx/media_player.py
+++ b/custom_components/vinx/media_player.py
@@ -81,18 +81,15 @@ class VinxDecoder(AbstractVinxMediaPlayerEntity):
     def __init__(self, lw3: LW3, device_information: DeviceInformation) -> None:
         super().__init__(lw3, device_information)
         self._source = None
-        self._source_list = None
         self._source_bidict = bidict()
 
     _attr_supported_features = MediaPlayerEntityFeature.SELECT_SOURCE
 
     async def async_update(self):
-        # Populate the source list only once. Sort it alphabetically, since the order of discovered devices
-        # may differ from device to device.
-        if self._source_list is None:
+        # Populate the source list only once
+        if len(self._source_bidict.items()) == 0:
             await self.populate_source_bidict()
-            self._source_list = sorted(list(self._source_bidict.values()))
-            _LOGGER.info(f"{self.name} source list populated with {len(self._source_list)} sources")
+            _LOGGER.info(f"{self.name} source list populated with {len(self.source_list)} sources")
 
         async with self._lw3.connection():
             # Query current source
@@ -109,7 +106,8 @@ class VinxDecoder(AbstractVinxMediaPlayerEntity):
 
     @property
     def source_list(self) -> list[str] | None:
-        return self._source_list
+        # Sort the list alphabetically, since the order of discovered devices may differ from device to device.
+        return sorted(list(self._source_bidict.values()))
 
     async def async_select_source(self, source: str) -> None:
         self._source = source

--- a/custom_components/vinx/media_player.py
+++ b/custom_components/vinx/media_player.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from bidict import bidict
@@ -60,7 +61,7 @@ class VinxDecoder(AbstractVinxMediaPlayerEntity):
         super().__init__(lw3, device_information)
         self._source = None
         self._source_bidict = bidict()
-        self._updating_sources = False
+        self._update_sources_lock = asyncio.Lock()
 
     _attr_supported_features = MediaPlayerEntityFeature.SELECT_SOURCE
 
@@ -106,16 +107,12 @@ class VinxDecoder(AbstractVinxMediaPlayerEntity):
         if event_device_label is None or event_device_label != self._device_information.device_label:
             _LOGGER.debug(f"Discarding {EVENT_DISCOVER_SOURCES} event for device label {event_device_label}")
 
-        # Protect against simultaneous calls
-        if not self._updating_sources:
-            try:
-                self._updating_sources = True
-
+        # Ignore concurrent events
+        if not self._update_sources_lock.locked():
+            async with self._update_sources_lock:
                 # Clear any existing items first
                 self._source_bidict.clear()
                 await self.populate_source_bidict()
-            finally:
-                self._updating_sources = False
 
     async def populate_source_bidict(self):
         """Queries the device for discovered devices, filters out everything that isn't a VINX encoder,

--- a/tests/test_vinx.py
+++ b/tests/test_vinx.py
@@ -1,0 +1,36 @@
+import unittest
+
+from homeassistant.helpers.device_registry import DeviceInfo, format_mac
+
+from custom_components.vinx import DeviceInformation, VinxEntity
+
+
+class VinxEntityTests(unittest.TestCase):
+    def test_unique_id_and_name(self):
+        device_information = DeviceInformation(
+            format_mac("00:11:22:33:44:55"),
+            "VINX HDMI JOTAIN",
+            "engelbart-decoder",
+            DeviceInfo(serial_number="123123"),
+        )
+
+        entity = VinxEntity(
+            device_information,
+            "media player",
+            "media_player",
+        )
+
+        self.assertEqual("vinx_00:11:22:33:44:55_media_player", entity.unique_id)
+        self.assertEqual("engelbart-decoder media player", entity.name)
+
+        # Without device_label should fall back to serial number
+        device_information.device_label = ""
+        self.assertEqual("VINX 123123 media player", entity.name)
+
+        # Without serial number should fall back to the most generic version
+        device_information.device_info = DeviceInfo()
+        self.assertEqual("VINX media player", entity.name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #11 

* add a "discover sources" button for decoder devices, fire an event when it's pressed
* handle the event in decoder media player entities
* fix a bug in the connection handling that could cause the connection to be disconnected if two parties simultaneously acquired the context