### PR TITLE
Allow device removal via the UI (v0.2.3)

### DIFF
--- a/custom_components/vinx/__init__.py
+++ b/custom_components/vinx/__init__.py
@@ -5,7 +5,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.device_registry import DeviceInfo, format_mac
+from homeassistant.helpers.device_registry import DeviceEntry, DeviceInfo, format_mac
 from pylw3 import LW3
 
 from custom_components.vinx.const import DOMAIN
@@ -87,3 +87,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
+) -> bool:
+    """Allow removing a device via the UI.
+
+    Each config entry represents a single VINX unit identified by MAC. When a
+    unit is replaced, the previous MAC's device becomes orphaned; HA only
+    exposes a Delete button for it if the integration opts in here.
+    """
+    return True

--- a/custom_components/vinx/manifest.json
+++ b/custom_components/vinx/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "vinx",
   "name": "VINX",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "codeowners": [
     "@Jalle19"
   ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-vinx"
-version = "0.2.2"
+version = "0.2.3"
 description = "Home Assistant integration for controlling Lightware VINX encoders and decoders"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
## Summary
- Implement `async_remove_config_entry_device` so the HA UI exposes a Delete button for orphan VINX devices.
- Bump version to 0.2.3 in `manifest.json` and `pyproject.toml`.

## Why
When a VINX unit is physically replaced the MAC changes, so HA creates fresh entities/device for the replacement but the old device and its (now unavailable) entities linger in the registry. Without this hook HA greys out the Delete button, forcing manual registry edits.

## Test plan
- [ ] Install 0.2.3 on the dev instance via HACS
- [ ] Verify the Delete button is active on an orphan classroom-proj-decoder device
- [ ] Confirm device removal also clears its entities